### PR TITLE
Fix creating match validation.

### DIFF
--- a/frontend/src/app/components/CreateMatch/SelectTeamForm.js
+++ b/frontend/src/app/components/CreateMatch/SelectTeamForm.js
@@ -33,7 +33,7 @@ export class SelectTeamForm extends Component {
                 selectedPlayerIds
             }
         }, () => {
-            const validPlayers = this.state.selectedPlayerIds.filter(playerId => playerId !== INVALID_PLAYER_ID)
+            const validPlayers = this.state.selectedPlayerIds.filter(playerId => playerId != INVALID_PLAYER_ID)
             this.props.teamChanged(validPlayers)
         })
     }


### PR DESCRIPTION
When creating a match you could have created an invalid match (with "None" considered as a player).

One had to add a player and then remove him by selecting "None".

The problem was with filtering players.
playerId is string
INVALID_PLAYER_ID is number

comparing with triple comparator always resulted in false. So no "None" player was filtered out.
