### PR TITLE
Add initial rating to user graphs

### DIFF
--- a/frontend/src/app/modules/matches/matches-computations.js
+++ b/frontend/src/app/modules/matches/matches-computations.js
@@ -17,9 +17,9 @@ export const generateMatchRatingChanges = (userId, userMatches) => userMatches.m
     }
 })
 
-export const generateRatingHistoryGraphForUser = (userMatches, userId, initialRating) => {
+export const plotRatingHistory = (userMatches, userId, initialRating) => {
   const reversedUserMatches = userMatches.reverse()
-  const firstMatchDate = userMatches[0] ? userMatches[0].date : null
+  const firstMatchDate = userMatches[0] && userMatches[0].date
   const graphStartDate = firstMatchDate ? new Date(firstMatchDate) : new Date()
   if (firstMatchDate) {
     graphStartDate.setDate(firstMatchDate.getDate() - 1)

--- a/frontend/src/app/modules/matches/matches-computations.js
+++ b/frontend/src/app/modules/matches/matches-computations.js
@@ -17,9 +17,15 @@ export const generateMatchRatingChanges = (userId, userMatches) => userMatches.m
     }
 })
 
-export const generateRatingHistoryGraphForUser = (userMatches, userId, initialRating) => userMatches
-  .reverse()
-  .map(
+export const generateRatingHistoryGraphForUser = (userMatches, userId, initialRating) => {
+  const reversedUserMatches = userMatches.reverse()
+  const firstMatchDate = userMatches[0] ? userMatches[0].date : null
+  const graphStartDate = firstMatchDate ? new Date(firstMatchDate) : new Date()
+  if (firstMatchDate) {
+    graphStartDate.setDate(firstMatchDate.getDate() - 1)
+  }
+  return [{ x: graphStartDate, y: initialRating }]
+    .concat(reversedUserMatches.map(
       function(match) {
         const didWin = didUserWin(userId, match)
         const change = didWin ? match.winningTeamRatingChange : match.losingTeamRatingChange
@@ -30,9 +36,10 @@ export const generateRatingHistoryGraphForUser = (userMatches, userId, initialRa
           y: this.rating,
           x: match.date
         }
-    },
-    { rating: initialRating }
-  )
+      },
+      { rating: initialRating }
+    ))
+}
 
 export const computeLongestWinStreak = (userId, userMatches) => {
     const initialState = {

--- a/frontend/src/app/modules/matches/matches-selectors.js
+++ b/frontend/src/app/modules/matches/matches-selectors.js
@@ -3,7 +3,7 @@ import {
   computeLongestWinStreak,
   computeWinRatio,
   generateMatchRatingChanges,
-  generateRatingHistoryGraphForUser
+  plotRatingHistory
 } from './matches-computations'
 import { getUser } from "../users/users-selectors"
 
@@ -53,5 +53,5 @@ export const getStatisticsForUser = createSelector(
 export const getRatingHistoryGraphForUser = createSelector(
   getLastMatchesForUser,
   getUser,
-  (userMatches, user) => generateRatingHistoryGraphForUser(userMatches, user.id, user.initialRating)
+  (userMatches, user) => plotRatingHistory(userMatches, user.id, user.initialRating)
 )


### PR DESCRIPTION
In order for the graph not to start with a completely upwards or downwards facing line, we assign the initial rating to the user one day before their first match. It's somehow as if the user has been added to the DB one day before their first match.