### PR TITLE
Add marks to the plot line to make it clear when a match was played

### DIFF
--- a/frontend/src/app/components/ProfileRatingGraph/index.js
+++ b/frontend/src/app/components/ProfileRatingGraph/index.js
@@ -6,12 +6,12 @@ import {
   YAxis,
   HorizontalGridLines,
   VerticalGridLines,
-  LineSeries,
+  LineMarkSeries,
 } from 'react-vis'
 
 import { getRatingHistoryGraphForUser } from '../../modules/matches/matches-selectors'
 import { Box, TextSpan } from '../../../styles/blocks'
-import { plotAxisStyle, plotGridStyle, plotLineStyle, plotMainGridStyle } from '../../../styles/svg'
+import { plotAxisStyle, plotGridStyle, plotLineStyle, plotMarkStyle, plotMainGridStyle } from '../../../styles/svg'
 
 const ProfileRatingGraph = props => (
   <Box Margin='0 5px 20px 5px'>
@@ -37,9 +37,10 @@ const ProfileRatingGraph = props => (
           tickLabelAngle={-45}
         />
         <YAxis style={plotAxisStyle} />
-        <LineSeries
+        <LineMarkSeries
           data={props.ratingHistoryGraph}
-          style={plotLineStyle}
+          lineStyle={plotLineStyle}
+          markStyle={plotMarkStyle}
         />
       </FlexibleWidthXYPlot>
     </div>

--- a/frontend/src/styles/svg.js
+++ b/frontend/src/styles/svg.js
@@ -6,6 +6,12 @@ export const plotLineStyle = {
   stroke: variables.TeamsColorWin,
 }
 
+export const plotMarkStyle = {
+  stroke: variables.TeamsColorWin,
+  strokeWidth: 2,
+  fill: variables.cBlack
+}
+
 export const plotAxisStyle = {
   fontSize: variables.fontSizeProfileDetails,
   fontWeight: '400',


### PR DESCRIPTION
Take a look at http://foos.salsitasoft.com/profile/12. Filip has not played any match in about 2 months, but from the graph, it's not clear at all. For all we know, he could've played 30 matches during that time, always gaining a little ELO just so that the end of the curve is so straight... The marks make it clear when matches were played.