### PR TITLE
gh-155: Automate migration

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: npm start

--- a/app.json
+++ b/app.json
@@ -20,7 +20,7 @@
   },
   "name": "foosball-rating",
   "scripts": {
-    "postdeploy": "cd backend && npm run create-schema && npm run create-test-db"
+    "postdeploy": "cd backend && npm run create-test-db"
   },
   "stack": "container"
 }

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,5 +1,9 @@
 build:
   docker:
     web: Dockerfile
+release:
+  image: web
+  command:
+    - cd backend && npm run create-schema
 run:
-  web: bash -c "npm start"
+  web: npm start


### PR DESCRIPTION
1. Removing Procfile - for some reason after removal deployment didn't work but then once I made run: web: as `npm start` instead of `bash -c 'npm start'` it works again... :eyes: 
Docs that heroku.yml should rewrite Procfile - https://devcenter.heroku.com/articles/build-docker-images-heroku-yml#run-defining-the-processes-to-run
2. Add release section to run create-schema - no need to create-schema in post-deply anymore