### PR TITLE
gh-167: Fix postdeploy failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM nginx
+ENTRYPOINT []
 
 RUN apt-get update >/dev/null
 RUN apt-get install -qq -y curl xz-utils >/dev/null


### PR DESCRIPTION
Just be sure that it helps - making a new PR.

Heroku support thread - https://help.heroku.com/906487

Adding ENTRYPOINT [] to Dockerfile so that our image doesn't inherit the ENTRYPOINT from the base image.