### PR TITLE
gh-175: Fix slackbot declaration

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -1,4 +1,4 @@
-import * as express from 'express'
+import express from 'express'
 import { NextFunction, Response, Request } from 'express'
 import * as bodyParser from 'body-parser'
 

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -5,6 +5,7 @@
     "sourceMap": true,
     "strict": true,
     "typeRoots": ["./types", "./node_modules/@types"],
+    "esModuleInterop": true
   },
   "exclude": [
     "node_modules"

--- a/backend/types/slackbots/index.d.ts
+++ b/backend/types/slackbots/index.d.ts
@@ -9,12 +9,14 @@ declare module 'slackbots' {
   interface PostConfig {
     as_user: boolean;
   }
-  /* eslint-disable import/no-default-export*/
-  export default class Slackbot {
+
+  class Slackbot {
     constructor(config: Config)
     on(eventName: string, cb: Function): void
     _api(apiName: string, config: ApiConfig): Promise<void>
     postTo(channelName: string, message: string, config: PostConfig): Promise<void>
     getGroupId(channelName: string): string
   }
+
+  export = Slackbot
 }


### PR DESCRIPTION
* Using `export = Slackbot` instead of `export default`
* enable esModuleInterop
* have to import similarly `express`
and things start to magically work :man_shrugging: 